### PR TITLE
Adding custom extension to turn of tags and make a shallow clone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.3</version>
+            <version>3.0.0</version>
             <exclusions>
                 <!-- To avoid ClassNotFoundException during InjectedTest -->
                 <exclusion>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -650,14 +650,12 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     private static class CustomExtension extends GitSCMExtension {
         @Override
         public void decorateCloneCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, CloneCommand cmd) throws IOException, InterruptedException, GitException {
-            cmd.shallow();
             cmd.tags(false);
             cmd.timeout(new Integer(600));
         }
 
         @Override
         public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
-            cmd.shallow(true);
             cmd.tags(false);
             cmd.timeout(new Integer(600));
         }


### PR DESCRIPTION
I tried using the existing `CloneOption` class, but it was going to take a ton of pipe-fitting to use the constructor exposed to the `step` `$class` in the Jenkinsfile. It was much easier to whip up our own extension like they did for the `MergeWith` extension.